### PR TITLE
fix(JS-34): relaxing style sources csp. Issue with Next/Image

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse, userAgent } from 'next/server';
  
 export function middleware(request: NextRequest) {
   // coming from https://github.com/vercel/next.js/blob/canary/examples/with-strict-csp/middleware.js
+  /**
+   * CSP style-src include 'unsafe-inline' because Next/Image adds inline styles as attributes
+   */
+  
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
   const cspHeader = `
     default-src 'self';
@@ -16,7 +20,7 @@ export function middleware(request: NextRequest) {
     block-all-mixed-content;
     upgrade-insecure-requests;
   `
-  // Replace newline characters and spaces
+  
   const contentSecurityPolicyHeaderValue = cspHeader
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
https://github.com/vercel/next.js/discussions/47966

and https://github.com/vercel/next.js/issues/24309

for additional info on the csp style source.